### PR TITLE
Gave better error for CAPTCHA

### DIFF
--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -87,7 +87,7 @@ function! vira#_connect() "{{{2
     " Check if Vira connected to the server
     if (s:vira_is_init != 1)
       " Inform user with possible errors and reset unconfigured information
-      echo "\nNot logged in! Check configuration and CAPTCHA"
+      echoe "Could not log into jira! Check authentication details or try entering CAPTCHA through web interface."
     endif
   endif
 


### PR DESCRIPTION
I was having trouble logging into jira, and it took me a long time to
troubleshoot the issue. It turned out that my password manager was not
pulling authentication details properly. After this, I was locked out
because of the CAPTCHA. I was not seeing the original error message,
which would have been very helpful.

Changing the `echo` to an `echoe` made the message appear properly.