### PR TITLE
I moved the state storage of all filter variables from vim to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ vira:
   server: https://jira.site.com
   project: VIRA
   assignee: Mike Boiko
-  priority: High, Highest
+  priority: [High, Highest]
 OtherProject:
   server: https://jira.othersite.com
   project: MAIN
@@ -134,7 +134,7 @@ __default__:
   server: https://jira.site.com
   project: VIRA
   assignee: Mike Boiko
-  priority: High, Highest
+  priority: [High, Highest]
 ```
 
 ### Browser
@@ -178,27 +178,6 @@ to be used to help configure Vira to work for you.
 #### Nulls
 
 - `g:vira_null_issue` - Text used when there is no issue.
-- `g:vira_null_project` - Text used when there is no project.
-
-#### Filters
-
-Filters are used to display the results of matching Jira issues.
-The following variables are used for the **Default** vaules along with
-the **Active** values for the filters. The default values are the
-important ones to be set and insure that filters return to desired
-state upon reset.
-
-- `g:vira_default_assignee` - Default `assignee` filter
-- `g:vira_default_issuetype` - Default `issuetype` filter
-- `g:vira_default_priority` - Default `issuetype` filter
-- `g:vira_default_report` - Default `report` filter
-- `g:vira_default_status` - Default `status` filter
-
-- `g:vira_active_assignee` - Active `assignee` filter
-- `g:vira_active_issuetype` - Active `issuetype` filter
-- `g:vira_active_priority` - Active `issuetype` filter
-- `g:vira_active_report` - Active `report` filter
-- `g:vira_active_status` - Active `status` filter
 
 ### Examples:
 
@@ -225,13 +204,6 @@ nnoremap <silent> <leader>vft :ViraFilterTypes<cr>
 
 " Filter reset
 nnoremap <silent> <leader>vfr :ViraFilterReset<cr>
-
-" Filters (.virarc project)
-let g:vira_default_assignee = ['']
-let g:vira_default_issuetype = ['']
-let g:vira_default_priority = ['']
-let g:vira_default_reporter = ['']
-let g:vira_default_status = ['To Do', 'In Progress']
 
 " Status
 statusline+=%{ViraStatusline()}

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -84,7 +84,7 @@ endfunction
 
 function! vira#_get_statusline() "{{{2
   return g:vira_active_issue
-  python3 vim.exec("let s:vira_statusline = " . vira_statusline())
+  " python3 vim.exec("let s:vira_statusline = " . vira_statusline())
 endfunction
 
 function! vira#_get_version() "{{{2

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -282,7 +282,8 @@ function! vira#_set_servers() "{{{2
 endfunction
 
 function! vira#_set_statuses() "{{{2
-  call vira#_set_filter('g:vira_active_status', '.')
+  let active_status = execute('python3 print(Vira.api.vim_filters["status"])')
+  call vira#_set_filter('active_status', '.')
 endfunction
 
 function! vira#_set_assignees() "{{{2

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -17,8 +17,6 @@ let s:vira_root_dir = fnamemodify(resolve(expand('<sfile>:p')), ':h') . '/..'
 
 let s:vira_todo_header = 'TODO'
 
-let s:vira_filters=['assignee', 'issuetype', 'priority', 'reporter', 'status']
-
 " Functions {{{1
 function! vira#_browse() "{{{2
   " Confirm an issue has been selected
@@ -244,14 +242,7 @@ function! vira#_quit() "{{{2
 endfunction
 
 function! vira#_reset_filters() " {{{2
-  for vira_filter in s:vira_filters
-    silent! call vira#_reset_filter(vira_filter)
-  endfor
-endfunction
-
-function! vira#_reset_filter(variable) "{{{2
-  " TODO-MB [200205] - Fix
-  execute 'let g:vira_active_' . a:variable . ' = g:vira_default_' . a:variable . '"'
+  python3 Vira.api.reset_filters()
 endfunction
 
 function! vira#_set_filter(variable, type) "{{{2

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -246,11 +246,11 @@ function! vira#_reset_filters() " {{{2
 endfunction
 
 function! vira#_reset_filter(variable) "{{{2
+  " TODO-MB [200205] - Fix
   execute 'let g:vira_active_' . a:variable . ' = g:vira_default_' . a:variable . '"'
 endfunction
 
 function! vira#_set_filter(variable, type) "{{{2
-  " TODO: VIRA-27 [191008] - New filter function remove old calls and replace with variables
   execute 'normal 0'
 
   if a:type == '<cWORD>'
@@ -258,7 +258,7 @@ function! vira#_set_filter(variable, type) "{{{2
   else
     let value = getline('.')
   endif
-  execute 'let ' . a:variable . ' = "' . value . '"'
+  execute 'python3 Vira.api.vim_filters["' . a:variable . '"] = "'. value .'"'
 
   if a:variable == 'g:vira_serv'
     call vira#_connect()
@@ -282,28 +282,23 @@ function! vira#_set_servers() "{{{2
 endfunction
 
 function! vira#_set_statuses() "{{{2
-  let active_status = execute('python3 print(Vira.api.vim_filters["status"])')
-  call vira#_set_filter('active_status', '.')
+  call vira#_set_filter('status', '.')
 endfunction
 
 function! vira#_set_assignees() "{{{2
-  let active_assignee = execute('python3 print(Vira.api.vim_filters["assignee"])')
-  call vira#_set_filter('active_assignee', '.')
+  call vira#_set_filter('assignee', '.')
 endfunction
 
 function! vira#_set_priorities() "{{{2
-  let active_priority = execute('python3 print(Vira.api.vim_filters["priority"])')
-  call vira#_set_filter('active_priority', '.')
+  call vira#_set_filter('priority', '.')
 endfunction
 
 function! vira#_set_reporters() "{{{2
-  let active_reporter = execute('python3 print(Vira.api.vim_filters["reporter"])')
-  call vira#_set_filter('active_reporter', '.')
+  call vira#_set_filter('reporter', '.')
 endfunction
 
 function! vira#_set_issuetypes() "{{{2
-  let active_issuetype = execute('python3 print(Vira.api.vim_filters["issuetype"])')
-  call vira#_set_filter('active_issuetype', '.')
+  call vira#_set_filter('issuetype', '.')
 endfunction
 
 function! vira#_todo() "{{{2

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -100,8 +100,9 @@ endfunction
 
 function! vira#_issue() "{{{2
   " Add issue only if a project has been selected
-  let active_project = execute('python3 print(Vira.api.vim_filters["project"])')
+  let active_project = execute('python3 print(Vira.api.vim_filters["project"])')[1:]
   if (active_project == "")
+    echo "Please select project before adding a new issue."
     return
   endif
 

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -262,7 +262,13 @@ function! vira#_set_filter(variable, type) "{{{2
   else
     let value = getline('.')
   endif
-  execute 'python3 Vira.api.vim_filters["' . a:variable . '"] = "'. value .'"'
+
+  " This function is used to set vim and python variables
+  if a:variable[:1] == 'g:'
+    execute 'let ' . a:variable . ' = "' . value . '"'
+  else
+    execute 'python3 Vira.api.vim_filters["' . a:variable . '"] = "'. value .'"'
+  endif
 
   if a:variable == 'g:vira_serv'
     call vira#_connect()

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -102,15 +102,19 @@ endfunction
 
 function! vira#_issue() "{{{2
   " Add issue only if a project has been selected
-  if !(g:vira_project == g:vira_null_project || g:vira_project == "")
-    let summary = input(g:vira_project . " - Issue Summary: ")
-    if !(summary == "")
-      let description = input(g:vira_project . " - Issue Description: ")
-      python3 Vira.api.add_issue(vim.eval('g:vira_project'), vim.eval('summary'), vim.eval('description'), "Bug")
-    else
-      echo "\nSummary should not be blank"
-    endif
+  let active_project = execute('python3 print(Vira.api.vim_filters["project"])')
+  if (active_project == "")
+    return
   endif
+
+  let summary = input(active_project . " - Issue Summary: ")
+  if !(summary == "")
+    let description = input(active_project . " - Issue Description: ")
+    python3 Vira.api.add_issue(vim.eval('summary'), vim.eval('description'), "Bug")
+  else
+    echo "\nSummary should not be blank"
+  endif
+
 endfunction
 
 function! vira#_print_report(list) " {{{2
@@ -270,13 +274,13 @@ function! vira#_set_issues() "{{{2
 endfunction
 
 function! vira#_set_projects() "{{{2
-  call vira#_set_filter('g:vira_project', '<cWORD>')
+  call vira#_set_filter('project', '<cWORD>')
 endfunction
 
 function! vira#_set_servers() "{{{2
   " Reset connection and clear filters before selecting new server
   call vira#_reset_filters()
-  let g:vira_project = 0
+  python3 Vira.api.vim_filters["project"] = ""
   let s:vira_connected = 0
   call vira#_set_filter('g:vira_serv', '<cWORD>')
 endfunction

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -287,19 +287,23 @@ function! vira#_set_statuses() "{{{2
 endfunction
 
 function! vira#_set_assignees() "{{{2
-  call vira#_set_filter('g:vira_active_assignee', '.')
+  let active_assignee = execute('python3 print(Vira.api.vim_filters["assignee"])')
+  call vira#_set_filter('active_assignee', '.')
 endfunction
 
 function! vira#_set_priorities() "{{{2
-  call vira#_set_filter('g:vira_active_priority', '.')
+  let active_priority = execute('python3 print(Vira.api.vim_filters["priority"])')
+  call vira#_set_filter('active_priority', '.')
 endfunction
 
 function! vira#_set_reporters() "{{{2
-  call vira#_set_filter('g:vira_active_reporter', '.')
+  let active_reporter = execute('python3 print(Vira.api.vim_filters["reporter"])')
+  call vira#_set_filter('active_reporter', '.')
 endfunction
 
 function! vira#_set_issuetypes() "{{{2
-  call vira#_set_filter('g:vira_active_issuetype', '.')
+  let active_issuetype = execute('python3 print(Vira.api.vim_filters["issuetype"])')
+  call vira#_set_filter('active_issuetype', '.')
 endfunction
 
 function! vira#_todo() "{{{2

--- a/plugin/vira.vim
+++ b/plugin/vira.vim
@@ -21,28 +21,9 @@ endif
 let g:vira_config_file_projects = get(g:, 'vira_config_file_projects', $HOME.'/.config/vira/vira_projects.json')
 let g:vira_config_file_servers = get(g:, 'vira_config_file_servers', $HOME.'/.config/vira/vira_servers.json')
 
-" Null values {{{2
+" Config variables {{{2
 let g:vira_null_issue = get(g:, 'vira_null_issue', 'None')
-let g:vira_null_project = get(g:, 'vira_null_project', 'None')
-
-" Connections and filters {{{2
-" Config
-let g:vira_default_assignee = get(g:, 'vira_default_assignee', '')
-let g:vira_default_issuetype = get(g:, 'vira_default_issuetype', '')
-let g:vira_default_priority = get(g:, 'vira_default_priority', '')
-let g:vira_default_reporter = get(g:, 'vira_default_reporter', '')
-let g:vira_default_status = get(g:, 'vira_default_status', ['To Do', 'In Progress'])
-
-" Active
-let g:vira_active_assignee = get(g:, 'vira_default_assignee', '')
-let g:vira_active_issuetype = get(g:, 'vira_default_issuetype', '')
-let g:vira_active_priority = get(g:, 'vira_default_priority', '')
-let g:vira_active_reporter = get(g:, 'vira_default_reporter', '')
-let g:vira_active_status = get(g:, 'vira_default_status', ['To Do', 'In Progress'])
-
-" Connections
 let g:vira_active_issue = get(g:, 'vira_active_issue', g:vira_null_issue)
-let g:vira_project = g:vira_null_project
 let g:vira_load_project_enabled = 1
 
 " Commands {{{1

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -314,7 +314,6 @@ class ViraAPI():
             else:
                 return
 
-        # TODO-MB [191205] - It would be more elegant to store state in python self object rather than vim global variables
         server = self.vira_projects.get(repo, {}).get('server')
         if server:
             vim.command(f'let g:vira_serv = "{server}"')
@@ -323,28 +322,10 @@ class ViraAPI():
         if project:
             vim.command(f'let g:vira_project = "{project}"')
 
-        # TODO-MB [200204] - re-factor this whole section with DRY principles
-        # Use keys from self.vim_filters
-
-        assignee = self.vira_projects.get(repo, {}).get('assignee')
-        if assignee:
-            self.vim_filters['assignee'] = assignee
-
-        issuetype = self.vira_projects.get(repo, {}).get('issuetype')
-        if issuetype:
-            self.vim_filters['issuetype'] = issuetype
-
-        priority = self.vira_projects.get(repo, {}).get('priority')
-        if priority:
-            self.vim_filters['priority'] = priority
-
-        reporter = self.vira_projects.get(repo, {}).get('reporter')
-        if reporter:
-            self.vim_filters['reporter'] = reporter
-
-        status = self.vira_projects.get(repo, {}).get('status')
-        if status:
-            self.vim_filters['status'] = status
+        for filterType in self.vim_filters.keys():
+            filterValue = self.vira_projects.get(repo, {}).get(filterType)
+            if filterValue:
+                self.vim_filters[filterType] = filterValue
 
     def query_issues(self):
         '''

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -338,9 +338,6 @@ class ViraAPI():
 
         query = ' AND '.join(q) + ' ORDER BY updated DESC'
 
-        # TODO-MB [200204] - TEST
-        print(query)
-
         issues = self.jira.search_issues(
             query, fields='summary,comment,status', json_result='True')
 

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -34,6 +34,7 @@ class ViraAPI():
             'assignee': '',
             'issuetype': '',
             'priority': '',
+            'project': '',
             'reporter': '',
             'status': ['To Do', 'In Progress']
         }
@@ -45,13 +46,13 @@ class ViraAPI():
 
         self.jira.add_comment(issue, comment)
 
-    def add_issue(self, project, summary, description, issuetype):
+    def add_issue(self, summary, description, issuetype):
         '''
         Get single issue by isuue id
         '''
 
         self.jira.create_issue(
-            project={'key': project},
+            project={'key': self.vim_filters['project']},
             summary=summary,
             description=description,
             issuetype={'name': issuetype})
@@ -318,10 +319,6 @@ class ViraAPI():
         if server:
             vim.command(f'let g:vira_serv = "{server}"')
 
-        project = self.vira_projects.get(repo, {}).get('project')
-        if project:
-            vim.command(f'let g:vira_project = "{project}"')
-
         for filterType in self.vim_filters.keys():
             filterValue = self.vira_projects.get(repo, {}).get(filterType)
             if filterValue:
@@ -332,21 +329,13 @@ class ViraAPI():
         Query issues based on current filters
         '''
 
-        query = ''
-        project = vim.eval('g:vira_project')
-        try:
-            if (project != '' and project != vim.eval('g:vira_null_project')):
-                query += 'project in (' + vim.eval('g:vira_project') + ') AND '
-        except:
-            query += ''
-
         q = []
         for filterType in self.vim_filters.keys():
             filter_str = self.filter_str(filterType)
             if filter_str:
                 q.append(filter_str)
 
-        query += ' AND '.join(q)
+        query = ' AND '.join(q) + ' ORDER BY updated DESC'
 
         # TODO-MB [200204] - TEST
         print(query)

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -116,13 +116,13 @@ class ViraAPI():
         '''
 
         if self.vim_filters.get(filterType, '') == '':
-            return ''
+            return
 
         selection = str(self.vim_filters[filterType]).strip('[]') if type(
             self.vim_filters[filterType]
         ) == list else "'" + self.vim_filters[filterType] + "'"
 
-        return f" AND {filterType} in ({selection})"
+        return f"{filterType} in ({selection})"
 
     def get_comments(self, issue):
         '''
@@ -336,15 +336,17 @@ class ViraAPI():
         project = vim.eval('g:vira_project')
         try:
             if (project != '' and project != vim.eval('g:vira_null_project')):
-                query += 'project in (' + vim.eval('g:vira_project') + ')'
+                query += 'project in (' + vim.eval('g:vira_project') + ') AND '
         except:
             query += ''
 
-        filterTypes = ['assignee', 'issuetype', 'priority', 'reporter', 'status']
-        for filterType in filterTypes:
-            query += self.filter_str(filterType)
+        q = []
+        for filterType in self.vim_filters.keys():
+            filter_str = self.filter_str(filterType)
+            if filter_str:
+                q.append(filter_str)
 
-        query += ' ORDER BY updated DESC'
+        query += ' AND '.join(q)
 
         # TODO-MB [200204] - TEST
         print(query)

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -110,16 +110,19 @@ class ViraAPI():
     def filter_str(self, filterType):
         '''
         Build a filter string to add to a JQL query
+        The string will look similar to one of these:
+            AND status in ('In Progress')
+            AND status in ('In Progress', 'To Do')
         '''
 
         if self.vim_filters.get(filterType, '') == '':
             return ''
 
-        selection = tuple(self.vim_filters[filterType]) if type(
+        selection = str(self.vim_filters[filterType]).strip('[]') if type(
             self.vim_filters[filterType]
-        ) == list else "('" + self.vim_filters[filterType] + "')"
+        ) == list else "'" + self.vim_filters[filterType] + "'"
 
-        return f' AND {filterType} in {selection}'
+        return f" AND {filterType} in ({selection})"
 
     def get_comments(self, issue):
         '''

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -30,7 +30,7 @@ class ViraAPI():
         except:
             print(f'Could not load {file_servers} or {file_projects}')
 
-        self.vim_filters = {
+        self.vim_filters_default = {
             'assignee': '',
             'issuetype': '',
             'priority': '',
@@ -38,6 +38,7 @@ class ViraAPI():
             'reporter': '',
             'status': ['To Do', 'In Progress']
         }
+        self.reset_filters()
 
     def add_comment(self, issue, comment):
         '''
@@ -344,6 +345,13 @@ class ViraAPI():
             query, fields='summary,comment,status', json_result='True')
 
         return issues['issues']
+
+    def reset_filters(self):
+        '''
+        Reset filters to their default values
+        '''
+
+        self.vim_filters = dict(self.vim_filters_default)
 
     def set_status(self, issue, status):
         '''


### PR DESCRIPTION
The user should configure all their default/project specific filter values in their vira_projects.json/yaml files

The folowing vim variables were deleted:
g:vira_default_assignee
g:vira_default_issuetype
g:vira_default_priority
g:vira_default_reporter
g:vira_default_status
g:vira_active_assignee
g:vira_active_issuetype
g:vira_active_priority
g:vira_active_reporter
g:vira_active_status
g:vira_null_project
g:vira_project

The state is now stored in self.vim_filters in vira_api.py

The only other point worth noting is that I deleted g:vira_null_project from the project entirely. The way the new python filters are setup, this varible was not required. I just wanted to let you know in case you were using this variable somehow in your .vimrc that I don't know of.