### PR TITLE
Fix :ViraBrowse in Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ __default__:
 
 ### Browser
 
-The default browser used for `:ViraBrowse` is the environment
-variable `$BROWSER`. Override this by setting `g:vira_browser`.
+By default, the `open` command will be used for `:ViraBrowse`. This will open
+the current issue in the default browser. Override this by setting
+`g:vira_browser`.
 
 ```
 let g:vira_browser = 'chromium'

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -64,14 +64,12 @@ function! vira#_browse() "{{{2
     let l:browser = g:vira_browser
   else | let l:browser = $BROWSER | endif
 
-  " User needs to define a browser
-  if l:browser == ''
-    echoerr 'Please set $BROWSER environment variable or g:vira_browser vim variable before running :ViraBrowse'
-    return
-  endif
-
   " Open current issue in browser
-  execute 'term ++close ' . l:browser . ' "' . l:url . '"'
+  if l:browser == ''
+    execute '!open ' . ' "' . l:url . '"'
+  else
+    execute '!' . l:browser . ' "' . l:url . '"'
+  endif
 endfunction
 
 function! vira#_prompt_start(type, ...) abort "{{{2


### PR DESCRIPTION
Neovim doesn't support running a command in the built in terminal using
'++close'. By default the 'open' command will now be used to open the
current issue in the default browser. Users can still override which
browser is used by using 'g:vira_browser'.