### PR TITLE
Only use 'open' or 'xdg-open' if they are executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,9 @@ __default__:
 
 ### Browser
 
-By default, the `default` command will be used for `:ViraBrowse`. This will open
-the current issue in the default browser. Override this by setting
-`g:vira_browser`.
-
+By default, the `open` or `xdg-open` command will be used by `:ViraBrowse` to open the current issue in the default
+browser. If either command is missing or you wish to override the default browser, you may set the `g:vira_browser`
+variable or provide the `BROWSER` environment variable.
 ```
 let g:vira_browser = 'chromium'
 ```

--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -61,8 +61,17 @@ function! vira#_browse() "{{{2
   " Set browser - either user defined or $BROWSER
   if exists('g:vira_browser') | let l:browser = g:vira_browser
   elseif exists('$BROWSER') | let l:browser = $BROWSER
-  elseif has('os2') || has('macunix') | let l:browser = 'open'
-  else | let l:browser = 'xdg-open' | endif
+  elseif executable('open') | let l:browser = 'open'
+  elseif executable('xdg-open') | let l:browser = 'xdg-open'
+  else
+    echoerr 'Please set $BROWSER environment variable or g:vira_browser vim variable before running :ViraBrowse'
+  endif
+
+  " There is no guarantee that the command provided by the user exists and is executable; if it's not provide an
+  " informative error as to why we can't open the current issue in the browser.
+  if l:browser != 'open' && l:browser != 'xdg-open' && !executable(l:browser)
+    echoerr "The browser '" . l:browser . "' does not exist or is not executable"
+  endif
 
   " Open current issue in browser
   silent! call execute('!' . l:browser . ' "' . l:url . '" > /dev/null 2>&1 &')


### PR DESCRIPTION
When using :ViraBrowse to open the current issue in the default browser
Vira will only try to use 'open' or 'xdg-open' if they exist and are
executable. This is a fallback for case where users have not provided
'g:vira_browser' or the 'BROWSER' environment variable.

Given a config/system where 'g:vira_browser' and 'BROWSER' are not set
and 'open', 'xdg-open' are not executable, an informative error will be
displayed asking the user to provide one of the two overriding
variables.

When provided with a command via '$BROWSER' or 'g:vira_browser' that is
not executable, :ViraBrowse will now display an informative error to the
user.