### PR TITLE
fix low contrast on status colours

### DIFF
--- a/syntax/vira_menu.vim
+++ b/syntax/vira_menu.vim
@@ -151,9 +151,9 @@ highlight viraDetailsMedium ctermfg=darkyellow guifg=darkyellow
 highlight viraDetailsStatusComplete ctermbg=darkgreen ctermfg=white guibg=darkgreen guifg=white cterm=bold gui=bold
 highlight viraDetailsStatusDone ctermbg=darkgreen ctermfg=white guibg=darkgreen guifg=white cterm=bold gui=bold
 highlight viraDetailsStatusInProgress ctermbg=darkblue ctermfg=white guibg=darkblue guifg=white cterm=bold gui=bold
-highlight viraDetailsStatusTodo ctermbg=grey ctermfg=black guibg=grey guifg=black cterm=bold gui=bold
-highlight viraDetailsStatusBacklog ctermbg=grey ctermfg=black guibg=grey guifg=black cterm=bold gui=bold
-highlight viraDetailsStatusSelected ctermbg=grey ctermfg=black guibg=grey guifg=black cterm=bold gui=bold
+highlight viraDetailsStatusTodo ctermbg=237 ctermfg=black guibg=grey guifg=black cterm=bold gui=bold
+highlight viraDetailsStatusBacklog ctermbg=237 ctermfg=black guibg=grey guifg=black cterm=bold gui=bold
+highlight viraDetailsStatusSelected ctermbg=237 ctermfg=black guibg=grey guifg=black cterm=bold gui=bold
 highlight viraDetailsTypeBug ctermfg=red guifg=red cterm=bold gui=bold
 highlight viraDetailsTypeEpic ctermfg=white ctermbg=53 guifg=white guibg=#5b005f  cterm=bold gui=bold
 highlight viraDetailsTypeStory ctermfg=lightgreen guifg=lightgreen  cterm=bold gui=bold

--- a/syntax/vira_report.vim
+++ b/syntax/vira_report.vim
@@ -168,12 +168,12 @@ highlight viraDetailsHighest ctermfg=darkred guifg=darkred
 highlight viraDetailsLow ctermfg=darkgreen guifg=darkgreen
 highlight viraDetailsLowest ctermfg=green guifg=green
 highlight viraDetailsMedium ctermfg=darkyellow guifg=darkyellow
-highlight viraDetailsStatusBacklog ctermbg=darkgrey ctermfg=white guibg=darkgrey guifg=white
+highlight viraDetailsStatusBacklog ctermbg=237 ctermfg=white guibg=darkgrey guifg=white
 highlight viraDetailsStatusComplete ctermbg=darkgreen ctermfg=white guibg=darkgreen guifg=white
 highlight viraDetailsStatusDone ctermbg=darkgreen ctermfg=white guibg=darkgreen guifg=white
 highlight viraDetailsStatusInProgress ctermbg=darkblue ctermfg=white guibg=darkblue guifg=white
-highlight viraDetailsStatusSelected ctermbg=grey ctermfg=black guibg=grey guifg=black
-highlight viraDetailsStatusTodo ctermbg=grey ctermfg=black guibg=grey guifg=black
+highlight viraDetailsStatusSelected ctermbg=237 ctermfg=black guibg=grey guifg=black
+highlight viraDetailsStatusTodo ctermbg=237 ctermfg=black guibg=grey guifg=black
 highlight viraDetailsStoryPoints ctermfg=darkyellow guifg=lightblue
 highlight viraDetailsTypeAssignee ctermfg=lightblue guifg=lightblue cterm=bold gui=bold
 highlight viraDetailsTypeBug ctermfg=red guifg=red


### PR DESCRIPTION
This fixes the low contrast ratio for certain statuses in a coloured terminal.

## Before:
![image](https://user-images.githubusercontent.com/18226001/107753561-571bb680-6d74-11eb-8811-3c6192f341f2.png)


## After:
![image](https://user-images.githubusercontent.com/18226001/107753435-2b003580-6d74-11eb-9381-b35f85db49e2.png)
