### PR TITLE
VIRA-276: Handle Jira tickets with no assignee

### DIFF
--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -777,7 +777,7 @@ class ViraAPI():
             user = str(issue['fields']['reporter']['displayName']
                       ) + ' ~ ' + issue['fields']['reporter'][self.users_type]
             self.users.add(user)
-            if type(issue['fields']['assignee']) == dict:
+            if 'assignee' in issue['fields'] and type(issue['fields']['assignee']) == dict:
                 user = str(issue['fields']['assignee']['displayName']
                           ) + ' ~ ' + issue['fields']['assignee'][self.users_type]
             self.users.add(user)


### PR DESCRIPTION
In some Jira instances, some tickets were found to have no 'assignee'
whatsoever, resulting in JSON exception thrown.  This commit gently
handles such cases.