### PR TITLE
VIRA-276: Don't skip project config if defaults are missing

### DIFF
--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -900,8 +900,8 @@ class ViraAPI():
                 repo = repo.split('/')[-1]
             if not self.vira_projects.get(repo):
                 repo = '__default__'
-            if not self.vira_projects.get('__default__'):
-                return
+                if not self.vira_projects.get('__default__'):
+                    return
 
         # Set server
         server = self.vira_projects.get(repo, {}).get('server')


### PR DESCRIPTION
If projects are defined according to `README.md` in
`vira_projects.json`, then the project configuration was still not
loaded because the implementation assumed that `__default__` must exist.

This commit changes the `load_project_config()` such that it cares about
`__default__` section only if the project name could not be determined
based on the input parameter nor the Git repository.