### PR TITLE
VIRA-276: Set default issue sort

### DIFF
--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -56,6 +56,8 @@ class ViraAPI():
             'status': '',
         }
 
+        self.userconfig_issuesort = 'updated DESC'
+
         self.users = set()
         self.versions = set()
         self.servers = set()


### PR DESCRIPTION
Issue sorting is required by further Jira queries but the
`userconfig_issuesort` is set only when configuring a project based on
`vira_projects.json`.  If projects are not defined, missing, or
whatever, then `userconfig_issuesort` is never set resulting in Jira
query errors.

This commit sets a default sane value to require users as little
configuration upfront as possible.