### PR TITLE
Don't append Null in non-empty server list

### DIFF
--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -710,9 +710,11 @@ class ViraAPI():
         '''
 
         try:
-            for server in self.vira_servers.keys():
-                print(server)
-            print('Null')
+            if self.vira_servers.keys():
+                for server in self.vira_servers.keys():
+                    print(server)
+            else:
+                print('Null')
         except:
             self.connect('')
 


### PR DESCRIPTION
By default, 'Null' is appended when a list of servers is displayed.
This makes sense if there are no servers configured to not leave the
list blank, but looks somewhat confusing if there are servers available.

This commit puts 'Null' in the server list only if no servers are
available (configured).