### PR TITLE
Use transitions instead of statuses for setting status

### DIFF
--- a/autoload/vira.vim
+++ b/autoload/vira.vim
@@ -602,10 +602,13 @@ function! vira#_set() "{{{2
         if value != "None" | let value = '"' . value . '"' | endif
         let variable = s:vira_epic_field
         execute 'python3 Vira.api.jira.issue("' . g:vira_active_issue . '").update(fields={"' . variable . '":' . value . '})'
-    elseif variable == 'transition_issue' || (variable == 'assign_issue' && !execute('silent! python3 Vira.api.jira.issue("'. g:vira_active_issue . '").update(assignee={"id": "' . substitute(value, 'currentUser', currentUser, '') . '"})'))
+    elseif variable == 'transition_issue'
+        let value = execute('python3 print(Vira.api.jira.find_transitionid_by_name("' . g:vira_active_issue . '", "' . value . '"))')[1:-1]
+        execute 'silent! python3 Vira.api.jira.transition_issue("' . g:vira_active_issue . '", "' . value . '")'
+    elseif (variable == 'assign_issue' && !execute('silent! python3 Vira.api.jira.issue("'. g:vira_active_issue . '").update(assignee={"id": "' . substitute(value, 'currentUser', currentUser, '') . '"})'))
         let value = substitute(value, 'currentUser', currentUser, '')
         let value = substitute(value, 'Unassigned', '-1', '')
-        execute 'silent! python3 Vira.api.jira.' . variable . '(vim.eval("g:vira_active_issue"), "' . value . '")'
+        execute 'silent! python3 Vira.api.jira.assign_issue("' . g:vira_active_issue . '", "' . value . '")'
 
     " FILTER
     else

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -721,8 +721,20 @@ class ViraAPI():
         Get my issues with JQL
         '''
 
+        jira_statuses = []
+
+        active_issue = vim.eval("g:vira_active_issue")
+        if active_issue:
+            try:
+                issue = self.jira.issue(active_issue)
+                jira_statuses = [t['name'] for t in self.jira.transitions(issue)]
+            except:
+                jira_statuses = self.jira.statuses()
+        else:
+            jira_statuses = self.jira.statuses()
+
         statuses = []
-        for status in self.jira.statuses():
+        for status in jira_statuses:
             if str(status) not in statuses:
                 statuses.append(str(status))
                 print(str(status))


### PR DESCRIPTION
A Jira instance may not necessarily allow to assign a status directly to
an issues.  Instead, for each issue allowed transitions need to be
obtained and used instead.