### PR TITLE
VIRA-296: Fix what should be an f string to make ViraBrowse work

### DIFF
--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -719,7 +719,7 @@ class ViraAPI():
                         print(server)
                 elif count == 1:
                         server = str(list(self.vira_servers.keys())[0])
-                        vim.command('let g:vira_serv = "{server}"')
+                        vim.command(f'let g:vira_serv = "{server}"')
                         self.connect(server)
             else:
                 print('Null')


### PR DESCRIPTION
ViraBrowse is broken and is being set to "{server}" string cause of this issue.

By making it an f string, the issue is fixed.