### PR TITLE
Bugfix/deprecated jql endpoint

### DIFF
--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -820,7 +820,7 @@ class ViraAPI():
         Get my issues with JQL
         '''
 
-        query = 'ORDER BY updated DESC'
+        query = 'created <= "2025-09-24" ORDER BY updated DESC'
         issues = self.jira.search_issues(
             query, fields='assignee, reporter', json_result='True', maxResults=5000, startAt=0)
 

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -820,7 +820,7 @@ class ViraAPI():
         Get my issues with JQL
         '''
 
-        query = 'created <= "2025-09-24" ORDER BY updated DESC'
+        query = 'created <= now() ORDER BY updated DESC'
         issues = self.jira.search_issues(
             query, fields='assignee, reporter', json_result='True', maxResults=5000, startAt=0)
 

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -842,7 +842,7 @@ class ViraAPI():
     def get_current_user(self, role):
         query = role + ' = currentUser()'
         issues = self.jira.search_issues(
-            query, fields=role, json_result='True', maxResults=-1, startAt=0)
+            query, fields=role, json_result='True', maxResults=5000, startAt=0)
 
         issue = issues['issues'][0]['fields']
         if self._has_field(issue, role):

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -822,7 +822,7 @@ class ViraAPI():
 
         query = 'ORDER BY updated DESC'
         issues = self.jira.search_issues(
-            query, fields='assignee, reporter', json_result='True', maxResults=-1)
+            query, fields='assignee, reporter', json_result='True', maxResults=5000)
 
         # Determine cloud/server jira
         self.users_type = 'accountId' if issues['issues'][0]['fields']['reporter'].get(

--- a/python/Vira/vira_api.py
+++ b/python/Vira/vira_api.py
@@ -297,7 +297,7 @@ class ViraAPI():
 
         # Get the issue requested
         issues = self.jira.search_issues(
-            'issue = "' + issue.key + '"', fields='summary,comment', json_result='True')
+            'issue = "' + issue.key + '"', fields='summary,comment', json_result='True', startAt=0)
 
         # Loop through all of the comments
         comments = ''
@@ -483,7 +483,7 @@ class ViraAPI():
             summary = self.jira.search_issues(
                 'issue = "' + active_issue + '"',
                 fields=','.join(['summary']),
-                json_result='True')['issues'][0]['fields']['summary']
+                json_result='True', startAt=0)['issues'][0]['fields']['summary']
             self.prompt_text = summary + self.prompt_text_commented
             return self.prompt_text
 
@@ -493,7 +493,7 @@ class ViraAPI():
             description = self.jira.search_issues(
                 'issue = "' + active_issue + '"',
                 fields=','.join(['description']),
-                json_result='True')['issues'][0]['fields'].get('description')
+                json_result='True', startAt=0)['issues'][0]['fields'].get('description')
             if description:
                 description = description.replace('\r\n', '\n')
             else:
@@ -589,7 +589,7 @@ class ViraAPI():
                     'issuetype', 'priority', 'status', 'created', 'updated', 'assignee',
                     'reporter', 'fixVersion', 'customfield_10106', 'labels', epicID
                 ]),
-            json_result='True')
+            json_result='True', startAt=0)
         issue = issues['issues'][0]['fields']
 
         # Prepare report data
@@ -822,7 +822,7 @@ class ViraAPI():
 
         query = 'ORDER BY updated DESC'
         issues = self.jira.search_issues(
-            query, fields='assignee, reporter', json_result='True', maxResults=5000)
+            query, fields='assignee, reporter', json_result='True', maxResults=5000, startAt=0)
 
         # Determine cloud/server jira
         self.users_type = 'accountId' if issues['issues'][0]['fields']['reporter'].get(
@@ -842,7 +842,7 @@ class ViraAPI():
     def get_current_user(self, role):
         query = role + ' = currentUser()'
         issues = self.jira.search_issues(
-            query, fields=role, json_result='True', maxResults=-1)
+            query, fields=role, json_result='True', maxResults=-1, startAt=0)
 
         issue = issues['issues'][0]['fields']
         if self._has_field(issue, role):
@@ -873,7 +873,7 @@ class ViraAPI():
                 fixVersion) != '[]' and str(fixVersion) != '':
             query = 'fixVersion = ' + fixVersion + ' AND project = "' + project + '"'
             issues = self.jira.search_issues(
-                query, fields='fixVersion', json_result='True', maxResults=1)
+                query, fields='fixVersion', json_result='True', maxResults=1, startAt=0)
 
             try:
                 issue = issues['issues'][0]['fields']['fixVersions'][0]
@@ -995,7 +995,8 @@ class ViraAPI():
             query,
             fields='summary,comment,status,statusCategory,issuetype,assignee',
             json_result='True',
-            maxResults=vim.eval('g:vira_issue_limit'))
+            maxResults=vim.eval('g:vira_issue_limit'),
+            startAt=0)
 
         return issues['issues']
 


### PR DESCRIPTION
Hi, I had an issue recently when trying to use your excellent plugin with our Jira server.

After a lot of digging I think it's because some command API are deprecated in jira cloud.

I wasn't able to open a connection and the `vira#_menu` was endlessly call.
In this PR I did fix the connection but I think an issue should be open to address the recursive call in case of error in the python script.

* By adding `startAt=0` into each `self.jira.search_issues` the python module can indirectly call `enhanced_search_issues` which solve the deprecated call to the API.
* the `-1` doesn't seems correct anymore so I've switched them for the max possible (*5000*)
* I had an issue with `Unbounded JQL queries are not allowed here.` when the function `get_users()` was call
  * by adding the `created <= "2025-09-24"` it seems to solve the Unbounded issue, you can put something else if you want,  I wasn't sure what to use.


Tell me if you need more detail.

Thanks